### PR TITLE
chore: bump ff, group to 0.13 and update dependent crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ byteorder = "1.4.3"
 ff = { version = "0.13", features = ["derive"]}
 hex-literal = "0.3.4"
 itertools = "0.9.0"
-nova-snark = "0.20.0"
+nova-snark = { version = "0.21.0", default-features = false }
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2.15"
 pasta_curves = { version = "0.5.1", features = ["repr-c", "serde"] }
@@ -37,8 +37,3 @@ js-sys = "0.3"
 default = []
 cuda = ["nova-snark/cuda"]
 opencl = ["nova-snark/opencl"]
-
-[patch.crates-io]
-# DO NOT COMMIT
-nova-snark = { version = "0.20", default-features = false, git = "https://github.com/huitseeker/nova", branch="bump_ff_group"}
-# DO NOT COMMIT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,15 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
 anyhow = "1.0.65"
-bellperson = { version = "0.24", default-features = false }
+bellperson = { version = "0.25", default-features = false }
 byteorder = "1.4.3"
-ff = { version = "0.12.0", features = ["derive"]}
+ff = { version = "0.13", features = ["derive"]}
 hex-literal = "0.3.4"
 itertools = "0.9.0"
 nova-snark = "0.20.0"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2.15"
-pasta_curves = { version = "0.5.2", features = ["repr-c", "serde"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.1", features = ["repr-c", "serde"] }
 serde = "1.0"
 serde_json = "1.0.85"
 
@@ -37,3 +37,8 @@ js-sys = "0.3"
 default = []
 cuda = ["nova-snark/cuda"]
 opencl = ["nova-snark/opencl"]
+
+[patch.crates-io]
+# DO NOT COMMIT
+nova-snark = { version = "0.20", default-features = false, git = "https://github.com/huitseeker/nova", branch="bump_ff_group"}
+# DO NOT COMMIT

--- a/browser-test/Cargo.toml
+++ b/browser-test/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 nova-scotia = { path = "../" }
-nova-snark = "0.20.0"
+nova-snark = { version = "0.21.0", default-features = false }
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2.15"
 serde = "1.0"
@@ -26,7 +26,3 @@ js-sys = "0.3"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[patch.crates-io]
-# DO NOT COMMIT
-nova-snark = { version = "0.20", default-features = false, git = "https://github.com/huitseeker/nova", branch="bump_ff_group"}
-# DO NOT COMMIT

--- a/browser-test/Cargo.toml
+++ b/browser-test/Cargo.toml
@@ -25,3 +25,8 @@ js-sys = "0.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[patch.crates-io]
+# DO NOT COMMIT
+nova-snark = { version = "0.20", default-features = false, git = "https://github.com/huitseeker/nova", branch="bump_ff_group"}
+# DO NOT COMMIT

--- a/src/circom/circuit.rs
+++ b/src/circom/circuit.rs
@@ -44,7 +44,7 @@ impl<'a, Fr: PrimeField> CircomCircuit<Fr> {
             // Public inputs do not exist, so we alloc, and later enforce equality from z values
             let f: Fr = {
                 match &self.witness {
-                    None => Fr::one(),
+                    None => Fr::ONE,
                     Some(w) => w[i],
                 }
             };
@@ -85,7 +85,7 @@ impl<'a, Fr: PrimeField> CircomCircuit<Fr> {
             // Public inputs do not exist, so we alloc, and later enforce equality from z values
             let f: Fr = {
                 match witness {
-                    None => Fr::one(),
+                    None => Fr::ONE,
                     Some(w) => w[i],
                 }
             };
@@ -101,7 +101,7 @@ impl<'a, Fr: PrimeField> CircomCircuit<Fr> {
             // Private witness trace
             let f: Fr = {
                 match witness {
-                    None => Fr::one(),
+                    None => Fr::ONE,
                     Some(w) => w[i + self.r1cs.num_inputs],
                 }
             };

--- a/src/circom/file.rs
+++ b/src/circom/file.rs
@@ -36,7 +36,7 @@ pub struct R1CSFile<Fr: PrimeField> {
 }
 
 pub(crate) fn read_field<R: Read, Fr: PrimeField>(mut reader: R) -> Result<Fr> {
-    let mut repr = Fr::zero().to_repr();
+    let mut repr = Fr::ZERO.to_repr();
     for digit in repr.as_mut().iter_mut() {
         // TODO: may need to reverse order?
         *digit = reader.read_u8()?;


### PR DESCRIPTION
- updates pasta_curves to 0.5.1, removes unneeded fork,
- updates bellperson to 0.25,

## TODO:
- [x] Merge [dependent PR](https://github.com/supranational/pasta-msm/pull/3) in pasta-msm
- [x] Merge [dependent PR](https://github.com/microsoft/Nova/pull/162) in Nova