### PR TITLE
feat: `continue_recursive_circuit ` api

### DIFF
--- a/examples/toy_bn254.rs
+++ b/examples/toy_bn254.rs
@@ -143,7 +143,7 @@ fn run_test(circuit_filepath: String, witness_gen_filepath: String) {
     // verify the recursive SNARK with the added steps
     println!("Verifying a RecursiveSNARK...");
     let start = Instant::now();
-    let res = recursive_snark.verify(&pp, iteration_count + 2, &start_public_input, &z0_secondary);
+    let res = recursive_snark.verify(&pp, iteration_count + iteration_count_continue, &start_public_input, &z0_secondary);
     println!(
         "RecursiveSNARK::verify: {:?}, took {:?}",
         res,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,12 +363,14 @@ where
 
 #[cfg(target_family = "wasm")]
 pub async fn add_step<G1, G2>(
+    recursive_snark: &mut RecursiveSNARK<G1, G2, C1<G1>, C2<G2>>,
+    last_zi: Vec<F<G1>>,
     witness_generator_file: FileLocation,
     r1cs: R1CS<F<G1>>,
-    private_inputs: Vec<HashMap<String, Value>>,
+    private_input: HashMap<String, Value>,
     start_public_input: Vec<F<G1>>,
     pp: &PublicParams<G1, G2, C1<G1>, C2<G2>>,
-) -> Result<RecursiveSNARK<G1, G2, C1<G1>, C2<G2>>, std::io::Error>
+) -> Result<(), std::io::Error>
 where
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
@@ -408,5 +410,5 @@ where
 
     fs::remove_file(witness_generator_output)?;
 
-    Ok(recursive_snark)
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ pub async fn continue_recursive_circuit<G1, G2>(
     last_zi: Vec<F<G1>>,
     witness_generator_file: FileLocation,
     r1cs: R1CS<F<G1>>,
-    private_input: Vec<HashMap<String, Value>>,
+    private_inputs: Vec<HashMap<String, Value>>,
     start_public_input: Vec<F<G1>>,
     pp: &PublicParams<G1, G2, C1<G1>, C2<G2>>,
 ) -> Result<(), std::io::Error>


### PR DESCRIPTION
The featured API allows adding a further IVC step to a `RecursiveSnark`. It is useful for any application in which all the steps are not known in advance. 

A few points: 

- It would be good if there was a way to access `zn_primary` from the `RecursiveSnark` instead of passing it as input to the `add_step` function
- It's still unclear to me what `circuit_secondary` and `z0_secondary` actually are. Is it safe to instantiate them to 0/default within the `add_step` function or is there a case in which the user may want to set a different value?