### PR TITLE
fix `current_dir()` call when using wasm generation

### DIFF
--- a/browser-test/test-client/package.json
+++ b/browser-test/test-client/package.json
@@ -69,7 +69,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js",
-    "build:wasm": "cd ../ && wasm-pack build --target web --out-dir ../client/public/pkg"
+    "build:wasm": "cd ../ && wasm-pack build --target web --out-dir ./test-client/public/pkg"
   },
   "eslintConfig": {
     "extends": [

--- a/browser-test/test-client/package.json
+++ b/browser-test/test-client/package.json
@@ -69,7 +69,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js",
-    "build:wasm": "cd ../circuits && wasm-pack build --target web --out-dir ../client/public/pkg"
+    "build:wasm": "cd ../ && wasm-pack build --target web --out-dir ../client/public/pkg"
   },
   "eslintConfig": {
     "extends": [

--- a/src/circom/wasm.rs
+++ b/src/circom/wasm.rs
@@ -5,7 +5,6 @@ use ff::PrimeField;
 use js_sys::Uint8Array;
 use nova_snark::traits::Group;
 use std::io::Cursor;
-use std::path::Path;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
@@ -61,7 +60,6 @@ where
 pub async fn generate_witness_from_wasm<Fr: PrimeField>(
     witness_wasm: &FileLocation,
     witness_input_json: &String,
-    _witness_output: &Path, // note: this is unused
 ) -> Vec<Fr> {
     let witness_wasm = match witness_wasm {
         FileLocation::PathBuf(_) => panic!("unreachable"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,6 @@ async fn compute_witness<G1, G2>(
     current_public_input: Vec<String>,
     private_input: HashMap<String, Value>,
     witness_generator_file: FileLocation,
-    witness_generator_output: &Path,
 ) -> Vec<<G1 as Group>::Scalar>
 where
     G1: Group<Base = <G2 as Group>::Scalar>,
@@ -136,10 +135,11 @@ where
         generate_witness_from_wasm::<F<G1>>(
             &witness_generator_file,
             &input_json,
-            &witness_generator_output,
         )
         .await
     } else {
+        let root = current_dir().unwrap(); // compute path only when generating witness from a binary
+        let witness_generator_output = root.join("circom_witness.wtns");
         let witness_generator_file = match &witness_generator_file {
             FileLocation::PathBuf(path) => path,
             FileLocation::URL(_) => panic!("unreachable"),
@@ -242,8 +242,6 @@ where
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
 {
-    let root = current_dir().unwrap();
-    let witness_generator_output = root.join("circom_witness.wtns");
 
     let iteration_count = private_inputs.len();
 
@@ -257,7 +255,6 @@ where
         current_public_input.clone(),
         private_inputs[0].clone(),
         witness_generator_file.clone(),
-        &witness_generator_output,
     )
     .await;
 
@@ -281,7 +278,6 @@ where
             current_public_input.clone(),
             private_inputs[i].clone(),
             witness_generator_file.clone(),
-            &witness_generator_output,
         )
         .await;
 
@@ -305,7 +301,6 @@ where
         );
         assert!(res.is_ok());
     }
-    fs::remove_file(witness_generator_output)?;
 
     Ok(recursive_snark)
 }
@@ -404,7 +399,6 @@ where
             current_public_input.clone(),
             private_inputs[i].clone(),
             witness_generator_file.clone(),
-            &witness_generator_output,
         )
         .await;
 


### PR DESCRIPTION
This is a proposed pr to get the in-browser proof generation example to work locally.

When targetting wasm [`create_recursive_circuit`](https://github.com/nalinbhardwaj/Nova-Scotia/blob/00085ece0e16c29a12f61866fa3588649620d7f7/src/lib.rs#L234) calls [`current_dir().unwrap()`](https://github.com/nalinbhardwaj/Nova-Scotia/blob/00085ece0e16c29a12f61866fa3588649620d7f7/src/lib.rs#L245). The built wasm which will be packaged will fail to generate the proof, since `current_dir()` is not supported in the browser.

Also, it could be nice to make [`WEBSITE_ROOT`](https://github.com/nalinbhardwaj/Nova-Scotia/blob/00085ece0e16c29a12f61866fa3588649620d7f7/browser-test/src/wasm.rs#L47) a parameter? So that the generated wasm is agnostic to where r1cs and wasm files are located. Will open a PR if this is of interest :)


Tangential: the example [app](https://effulgent-liger-07e9d0.netlify.app/) seems down as of now?