### PR TITLE
fix `current_dir()` call when using wasm generation 2: continue_recursive_circuit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,9 +381,6 @@ where
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
 {
-    let root = current_dir().unwrap();
-    let witness_generator_output = root.join("circom_witness.wtns");
-
     let iteration_count = private_inputs.len();
 
     let mut current_public_input = last_zi
@@ -423,8 +420,6 @@ where
 
         assert!(res.is_ok());
     }
-
-    fs::remove_file(witness_generator_output)?;
 
     Ok(())
 }


### PR DESCRIPTION
Issue #37 details how `create_recursive_circuit` calls `current_dir()`. This was fixed for `create_recursive_circuit` but not `continue_recursive_circuit`. This PR makes minimal changes to the wasm targeted `continue_recursive_circuit` to remove fs operations as was done in #37.

I don't think there is a wasm test suite so I haven't run anything in this repository specifically, but I have confirmed the intended functionality is achieved with this PR in an [external repository](https://github.com/Mach-34/babyjubjub-ecdsa/blob/98ffe65c6a38527ddc8fdc88efb46f53f646758b/packages/nova/src/wasm.rs#L253-L308)

edit: need to fix the ci